### PR TITLE
ci: 添加 all-green 方便分支保护检查

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -37,3 +37,13 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           env_vars: OS,PYTHON_VERSION
+
+  check:
+    if: always()
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
+      with:
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
分支保护时就不需要手动把不同平台都加上去了，修改也更加方便。