### PR TITLE
fix: 修复设置多个分隔符时无法匹配的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复设置多个分隔符时无法匹配的问题
+
 ## [0.0.4] - 2023-03-06
 
 ### Added

--- a/nonebot_plugin_treehelp/data_source.py
+++ b/nonebot_plugin_treehelp/data_source.py
@@ -100,8 +100,12 @@ def get_plugin_help(bot: "Bot", name: str, tree: bool = False) -> Optional[str]:
 
     plugin = plugins.get(name)
     if not plugin:
-        command = name.split("".join(global_config.command_sep))
-        plugin = _commands.get(tuple(command))
+        # str.split 只支持单个分隔符
+        # 用 re 又太麻烦了，直接遍历所有分隔符，找到就停止
+        for sep in global_config.command_sep:
+            plugin = _commands.get(tuple(name.split(sep)))
+            if plugin:
+                break
     if not plugin:
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,13 @@
 import nonebot
 import pytest
+from nonebug import NONEBOT_INIT_KWARGS, App
 from nonebug.app import App
 
 from .utils import clear_plugins
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.stash[NONEBOT_INIT_KWARGS] = {"command_sep": [".", "。"]}
 
 
 @pytest.fixture

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -127,3 +127,12 @@ async def test_help_by_command(app: App):
         ctx.receive_event(bot, event)
         ctx.should_call_send(event, "复杂功能\n\n/复杂功能\n\n二级功能 # 测试插件二级插件", True)
         ctx.should_finished()
+
+    async with app.test_matcher(help_cmd) as ctx:
+        bot = ctx.create_bot()
+        message = message = make_fake_message()("/help sub。alias")
+        event = make_fake_event(_message=message)()
+
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(event, "复杂功能\n\n/复杂功能\n\n二级功能 # 测试插件二级插件", True)
+        ctx.should_finished()


### PR DESCRIPTION
忘记 str.split 只支持单个分隔符了。